### PR TITLE
Add :SCALAR option to CONVERT-ROW function.

### DIFF
--- a/src/db.lisp
+++ b/src/db.lisp
@@ -85,6 +85,10 @@
                name)))
     (when row
       (case as
+        (:scalar
+         (if (not (listp row))
+             row
+             (error "The row is a list, not a scalar value.")))
         ((null property-list)
          (iter (for (column value) on row by #'cddr)
            (collect (prettify-column-name column))


### PR DESCRIPTION
This PR adds `:scalar` option to `convert-row` function's `as` parameter, which option makes the function possible to handle scalar result values of SQL statements.

It is useful on using `retrieve-one` function with `UPDATE` statement to get the number of actually affected rows.
