### PR TITLE
Fix connections breaking for sqlite3 file DBs

### DIFF
--- a/src/db.lisp
+++ b/src/db.lisp
@@ -44,7 +44,7 @@
        (setf (gethash connect-args *connections*)
              (apply #'dbi:connect
                     connect-args)))
-      ((not (dbi:ping conn))
+      ((or (member :sqlite3 connect-args) (not (dbi:ping conn)))
        (dbi:disconnect conn)
        (remhash connect-args *connections*)
        (apply #'connect-cached connect-args))


### PR DESCRIPTION
`db:ping` isn't the right test for file DBs like sqlite3. This applies the correct(?) case for sqlite3, bypassing the `db:ping` test.

This patch attempts to address #14 and seems to work from my tests.
Is this sufficient? Does this break anything?