### PR TITLE
Fix json conversion for single-item plists

### DIFF
--- a/src/json.lisp
+++ b/src/json.lisp
@@ -15,8 +15,18 @@
 (syntax:use-syntax :annot)
 
 (defun association-list-p (object)
-  (and (trivial-types:association-list-p object)
-       (not (eq (caar object) (caadr object)))))
+  (and (listp object)
+       (listp (car object))
+       (destructuring-bind (a . b) (car object)
+	 (not (listp b)))))
+
+(defun property-list-p (object)
+  (and (listp object)
+       (not (null object))
+       (listp (cdr object))
+       (not (null (cdr object)))
+       (destructuring-bind (a b &rest r) object
+	 (keywordp a))))
 
 (defun object-to-plist (object)
   (let ((slots (c2mop:class-direct-slots (class-of object))))

--- a/t/json.lisp
+++ b/t/json.lisp
@@ -5,7 +5,7 @@
         :cl-test-more))
 (in-package :datafly-test.json)
 
-(plan 10)
+(plan 11)
 
 (defvar *timestamp*
   (local-time:unix-to-timestamp 1360850770))
@@ -18,6 +18,10 @@
                    (:name "Tomohiro" :status :temporary :created-at ,(local-time:timestamp+ *timestamp* 1 :day))))
     "[{\"name\":\"Eitaro\",\"status\":\"registered\",\"createdAt\":1360850770},{\"name\":\"Tomohiro\",\"status\":\"temporary\",\"createdAt\":1360937170}]"
     "Property List")
+
+(is (encode-json `((:name "Eitaro" :status :registered :created-at ,*timestamp*)))
+    "[{\"name\":\"Eitaro\",\"status\":\"registered\",\"createdAt\":1360850770}]"
+    "Single Item List With Property List (Simulating single row returned by retrieve-all)")
 
 (is (encode-json `((:name . "Eitaro") (:status . :registered) (:created-at . ,*timestamp*)))
     "{\"name\":\"Eitaro\",\"status\":\"registered\",\"createdAt\":1360850770}"


### PR DESCRIPTION
It looks like `association-list-p` and `property-list-p` were satisfied by too many types of inputs.
This should address #3 . The test case submitted in #4 was also added. However I had trouble adding the proper credit by pulling in the change through git...