### PR TITLE
Update (syntax:use-syntax :annot) -> (annot:enable-annot-syntax)

### DIFF
--- a/src/cache.lisp
+++ b/src/cache.lisp
@@ -7,7 +7,7 @@
                 :compose))
 (in-package :datafly.cache)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (defvar *model-accessors* (make-hash-table :test 'eq))
 

--- a/src/db.lisp
+++ b/src/db.lisp
@@ -22,7 +22,7 @@
                 :association-list))
 (in-package :datafly.db)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defvar *connection* nil)

--- a/src/inflate.lisp
+++ b/src/inflate.lisp
@@ -15,7 +15,7 @@
                 :octets-to-string))
 (in-package :datafly.inflate)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defun tinyint-to-boolean (val)

--- a/src/json.lisp
+++ b/src/json.lisp
@@ -12,7 +12,7 @@
                 #:copy-hash-table))
 (in-package :datafly.json)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 (defun association-list-p (object)
   (and (listp object)

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -3,7 +3,7 @@
   (:use :cl))
 (in-package datafly.logger)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defvar *trace-sql* nil)

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -20,7 +20,7 @@
                 :make-keyword))
 (in-package :datafly.model)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defmacro defmodel (name-and-options &body slot-descriptions)

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -3,7 +3,7 @@
   (:use :cl))
 (in-package :datafly.util)
 
-(syntax:use-syntax :annot)
+(annot:enable-annot-syntax)
 
 @export
 (defun partition-if (pred sequence &key from-end (start 0) end (key #'identity))


### PR DESCRIPTION
This pull request updates the use of cl-annot.

Older versions of cl-annot cause the next problem when I try to load a system that depends on it:
```
debugger invoked on a EDITOR-HINTS.NAMED-READTABLES:READER-MACRO-CONFLICT in thread
#<THREAD tid=74797 "main thread" RUNNING {10013E8073}>:
  Reader macro conflict while trying to merge the dispatch macro characters #\#
  #\R from #<NAMED-READTABLE CL-ANNOT::SYNTAX {1001ECDBD3}> into
  #<READTABLE {1005E3BD83}>.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE                     ] Overwrite #\# in #<NAMED-READTABLE :CURRENT {1005E3BD83}>.
  1: [RETRY                        ] Retry
                                     compiling #<CL-SOURCE-FILE "datafly" "src" "logger">.
  2: [ACCEPT                       ] Continue, treating
                                     compiling #<CL-SOURCE-FILE "datafly" "src" "logger">
                                     as having been successful.
  3:                                 Retry ASDF operation.
  4: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the
                                     configuration.
  5:                                 Retry ASDF operation.
  6:                                 Retry ASDF operation after resetting the
                                     configuration.
  7: [ABORT                        ] Give up on "fql"
  8: [REGISTER-LOCAL-PROJECTS      ] Register local projects and try again.
  9:                                 Exit debugger, returning to top level.

(EDITOR-HINTS.NAMED-READTABLES:MERGE-READTABLES-INTO #<READTABLE {1005E3BD83}> #<NAMED-READTABLE CL-ANNOT::SYNTAX {1001ECDBD3}>)
   source: (CHECK-READER-MACRO-CONFLICT FROM TO CHAR SUBCHAR)
```