### PR TITLE
Allows connection as a keyword argument to retrieve-one, retrieve-all, and execute.

### DIFF
--- a/src/db.lisp
+++ b/src/db.lisp
@@ -184,7 +184,7 @@
       results)))
 
 @export
-(defun retrieve-one (statement &key by = (as *default-row-type*) (prettify t))
+(defun retrieve-one (statement &key by = (as *default-row-type*) (prettify t) (*connection* *connection*))
   (assert (eq (null by) (null =)))
   (when (keywordp statement)
     (setf statement
@@ -207,7 +207,7 @@
       (second (retrieve-one statement))))
 
 @export
-(defun retrieve-all (statement &key (as *default-row-type*) (prettify t))
+(defun retrieve-all (statement &key (as *default-row-type*) (prettify t) (*connection* *connection*))
   (mapcar (lambda (row)
             (convert-row row :as as :prettify prettify))
           (execute-with-connection *connection* statement)))
@@ -220,6 +220,6 @@
           (retrieve-all statement :prettify prettify)))
 
 @export
-(defun execute (statement)
+(defun execute (statement &key (*connection* *connection*))
   (execute-with-connection *connection* statement)
   (values))


### PR DESCRIPTION
I found this feature useful for one of my school projects, where I want to have different parts of my code accessing different databases. I just added the keyword argument to retrieve-one, retrieve-all, and execute, since they don't already have &optional parameters.